### PR TITLE
Make pcap-broker go installable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ WORKDIR /app
 COPY . /app
 
 RUN go mod download
-RUN go build ./cmd/pcap-broker
+RUN go build .
 
 ENTRYPOINT ["./pcap-broker"]

--- a/README.md
+++ b/README.md
@@ -15,10 +15,16 @@ More information on PCAP-over-IP can be found here:
 
 ## Building
 
-To build `pcap-broker`:
+Building `pcap-broker` requires the `libpcap` development headers, on Debian you can install it with:
 
 ```shell
-$ go build ./cmd/pcap-broker
+$ apt install libpcap-dev
+```
+
+To build from source, clone this repository and run:
+
+```shell
+$ go build .
 $ ./pcap-broker --help
 ```
 
@@ -27,6 +33,13 @@ Or you can build the Docker container:
 ```shell
 $ docker build -t pcap-broker .
 $ docker run -it pcap-broker --help
+```
+
+Alternatively, install directly using `go`:
+
+```shell
+$ go install github.com/fox-it/pcap-broker@latest
+$ pcap-broker --help
 ```
 
 ## Running

--- a/cmd/pcap-broker/main.go
+++ b/cmd/pcap-broker/main.go
@@ -1,4 +1,4 @@
-package main
+package pcap_broker
 
 import (
 	"context"
@@ -34,7 +34,7 @@ var (
 	json            = flag.Bool("json", false, "enable json logging")
 )
 
-func main() {
+func Main() {
 	flag.Parse()
 
 	if !*json {

--- a/main.go
+++ b/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	pcap_broker "github.com/fox-it/pcap-broker/cmd/pcap-broker"
+)
+
+func main() {
+	pcap_broker.Main()
+}


### PR DESCRIPTION
This mainly adds a main.go file in the project root so it's easier to install pcap-broker using `go install`:

    $ go install github.com/fox-it/pcap-broker@latest

Or install the main branch:

    $ go install github.com/fox-it/pcap-broker@main